### PR TITLE
キーコードマクロ名をKEY_XXXからPS2_XXXに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Arduino IDE 1.6.10以上 + Arduino STM32環境がインストールされてい�
 
 ## ライブラリのインストール
 - Arduino IDEを起動していない状態で  
-フォルダ **TKeyboard** を各自のArduino_STM32インストール先フォルダの  
-**Arduino_STM32\\STM32F1\\libraries\\** に配置して下さい。
+フォルダ **TKeyboard** を各自のライブラリ用ディレクトリlibrariesに配置して下さい。  
 - 配置後、Arduino IDEを起動して、メニュー [ファイル]-[スケッチの例]をクリックして  
 ライブラリ**TKeyboard**が追加されていることを確認して下さい。
 
 ## ハードウェア構成
 **(注意)**  
-PS/2 I/FのCLK、DATAの信号電圧に5Vを利用する場合は、
+PS/2インタフェースのCLK、DATA信号の電圧に5Vを利用する場合は、  
 5Vトレラント(5V耐性)のピンを利用して下さい。  
-SM32F103C8T6の5Vトレラント対応ピン  
+
+SM32F103C8T6の5Vトレラント対応ピン
 - PA8,PA9,PA10,PA11,PA12,PA13,PA14,PA15
 - PB3,PB4,PB6,PB7,PB8,PB9,PB10,PB11PB12,PB13,PB14,PB15
 
@@ -220,7 +220,7 @@ PS/2通信方向をホスト=>キーボードの方向に設定し、
 キーボードからキー入力情報を取得します。  
 
 - 書式  
-`keyEvent read() )`
+`keyEvent read()`
 
 - 引数  
 なし
@@ -313,171 +313,171 @@ Windowsキーが押されている状況がセットされます。
 |----------|------------|-----------------------|
 |KEY_ERROR|        0xFF |キーコードエラー
 |KEY_NONE |           0 | 入力なし
-| KEY_L_Alt|          1	| [左Alt]
-| KEY_L_Shift|		  2	| [左Shift]
-| KEY_L_Ctrl|		  3	| [左Ctrl]
-| KEY_R_Shift|		  4	| [右Shift]
-| KEY_R_Alt|		  5	| [右Alt]
-| KEY_R_Ctrl|		  6	| [右Ctrl]
-| KEY_L_GUI|		  7	| [左Windowsキー]
-| KEY_R_GUI|		  8	| [右Windowsキー]
-| KEY_NumLock|		  9	| [NumLock]
-| KEY_ScrollLock|	 10	| [ScrollLock]
-| KEY_CapsLock|	     11	| [CapsLock]
-| KEY_PrintScreen|	 12	| [PrintScreen]
-| KEY_HanZen|		 13	| [半角/全角 漢字]
-| KEY_Insert|		 14	| [Insert]
-| KEY_Home|		     15	| [Home]
-| KEY_Pause|		 16	| [Pause]
-| KEY_Romaji|		 17	| [カタカナ ひらがな ローマ字]
-| KEY_APP|			 18	| [メニューキー]
-| KEY_Henkan|		 19	| [変換]
-| KEY_Muhenkan|	     20	| [無変換]
-| KEY_PageUp|		 21	| [PageUp]
-| KEY_PageDown|	     22	| [PageDown]
-| KEY_End|			 23	| [End]
-| KEY_L_Arrow|		 24	| [←]
-| KEY_Up_Arrow|	     25	| [↑]
-| KEY_R_Arrow|		 26	| [→]
-| KEY_Down_Arrow|	 27	| [↓]
-| KEY_ESC|			 30	| [ESC]
-| KEY_Tab| 		     31	| [Tab]
-| KEY_Space|		 32	| [空白]
-| KEY_Backspace|	 33	| [BackSpace]
-| KEY_Delete|		 34	| [Delete]
-| KEY_Enter|		 35	| [Enter]
+| PS2_L_Alt|          1	| [左Alt]
+| PS2_L_Shift|		  2	| [左Shift]
+| PS2_L_Ctrl|		  3	| [左Ctrl]
+| PS2_R_Shift|		  4	| [右Shift]
+| PS2_R_Alt|		  5	| [右Alt]
+| PS2_R_Ctrl|		  6	| [右Ctrl]
+| PS2_L_GUI|		  7	| [左Windowsキー]
+| PS2_R_GUI|		  8	| [右Windowsキー]
+| PS2_NumLock|		  9	| [NumLock]
+| PS2_ScrollLock|	 10	| [ScrollLock]
+| PS2_CapsLock|	     11	| [CapsLock]
+| PS2_PrintScreen|	 12	| [PrintScreen]
+| PS2_HanZen|		 13	| [半角/全角 漢字]
+| PS2_Insert|		 14	| [Insert]
+| PS2_Home|		     15	| [Home]
+| PS2_Pause|		 16	| [Pause]
+| PS2_Romaji|		 17	| [カタカナ ひらがな ローマ字]
+| PS2_APP|			 18	| [メニューキー]
+| PS2_Henkan|		 19	| [変換]
+| PS2_Muhenkan|	     20	| [無変換]
+| PS2_PageUp|		 21	| [PageUp]
+| PS2_PageDown|	     22	| [PageDown]
+| PS2_End|			 23	| [End]
+| PS2_L_Arrow|		 24	| [←]
+| PS2_Up_Arrow|	     25	| [↑]
+| PS2_R_Arrow|		 26	| [→]
+| PS2_Down_Arrow|	 27	| [↓]
+| PS2_ESC|			 30	| [ESC]
+| PS2_Tab| 		     31	| [Tab]
+| PS2_Space|		 32	| [空白]
+| PS2_Backspace|	 33	| [BackSpace]
+| PS2_Delete|		 34	| [Delete]
+| PS2_Enter|		 35	| [Enter]
 
 (2)通常キー（ASCIIコード変換可能キー)のキーコード  
 
 | 定義名 | 値 |意味|
 |--------|----------|------|
-| KEY_Colon      |36| [: *]
-| KEY_Semicolon  |37| [; +]
-| KEY_Kamma      |38| [, <]
-| KEY_minus      |39| [- =]
-| KEY_Dot        |40| [. >]
-| KEY_Question   |41| [/ ?]
-| KEY_AT         |42| [@ \`]
-| KEY_L_brackets |43| [[ {]
-| KEY_Pipe       |44| [\｜]
-| KEY_R_brackets |45| [] }]
-| KEY_Hat        |46| [^ ~]
-| KEY_Ro         |47| [\ _ ろ]
-| KEY_0          |48| [0 )]
-| KEY_1		     |49| [1 !]
-| KEY_2			 |50| [2 @]
-| KEY_3			 |51| [3 #]
-| KEY_4			 |52| [4 $]
-| KEY_5			 |53| [5 %]
-| KEY_6			 |54| [6 ^]
-| KEY_7			 |55| [7 &]
-| KEY_8			 |56| [8 *]
-| KEY_9			 |57| [9 (]
-| KEY_Pipe2      |58| [\｜] (USキーボード用)
-| KEY_A			 |65| [a A]
-| KEY_B			 |66| [b B]
-| KEY_C			 |67| [c C]
-| KEY_D			 |68| [d D]
-| KEY_E			 |69| [e E]
-| KEY_F			 |70| [f F]
-| KEY_G			 |71| [g G]
-| KEY_H			 |72| [h H]
-| KEY_I			 |73| [i I]
-| KEY_J			 |74| [j J]
-| KEY_K			 |75| [k K]
-| KEY_L			 |76| [l L]
-| KEY_M			 |77| [m M]
-| KEY_N			 |78| [n N]
-| KEY_O			 |79| [o O]
-| KEY_P			 |80| [p P]
-| KEY_Q			 |81| [q Q]
-| KEY_R			 |82| [r R]
-| KEY_S			 |83| [s S]
-| KEY_T			 |84| [t T]
-| KEY_U			 |85| [u U]
-| KEY_V			 |86| [v V]
-| KEY_W			 |87| [w W]
-| KEY_X			 |88| [x X]
-| KEY_Y			 |89| [y Y]
-| KEY_Z			 |90| [z Z]
+| PS2_Colon      |36| [: *]
+| PS2_Semicolon  |37| [; +]
+| PS2_Kamma      |38| [, <]
+| PS2_minus      |39| [- =]
+| PS2_Dot        |40| [. >]
+| PS2_Question   |41| [/ ?]
+| PS2_AT         |42| [@ \`]
+| PS2_L_brackets |43| [[ {]
+| PS2_Pipe       |44| [\｜]
+| PS2_R_brackets |45| [] }]
+| PS2_Hat        |46| [^ ~]
+| PS2_Ro         |47| [\ _ ろ]
+| PS2_0          |48| [0 )]
+| PS2_1		     |49| [1 !]
+| PS2_2			 |50| [2 @]
+| PS2_3			 |51| [3 #]
+| PS2_4			 |52| [4 $]
+| PS2_5			 |53| [5 %]
+| PS2_6			 |54| [6 ^]
+| PS2_7			 |55| [7 &]
+| PS2_8			 |56| [8 *]
+| PS2_9			 |57| [9 (]
+| PS2_Pipe2      |58| [\｜] (USキーボード用)
+| PS2_A			 |65| [a A]
+| PS2_B			 |66| [b B]
+| PS2_C			 |67| [c C]
+| PS2_D			 |68| [d D]
+| PS2_E			 |69| [e E]
+| PS2_F			 |70| [f F]
+| PS2_G			 |71| [g G]
+| PS2_H			 |72| [h H]
+| PS2_I			 |73| [i I]
+| PS2_J			 |74| [j J]
+| PS2_K			 |75| [k K]
+| PS2_L			 |76| [l L]
+| PS2_M			 |77| [m M]
+| PS2_N			 |78| [n N]
+| PS2_O			 |79| [o O]
+| PS2_P			 |80| [p P]
+| PS2_Q			 |81| [q Q]
+| PS2_R			 |82| [r R]
+| PS2_S			 |83| [s S]
+| PS2_T			 |84| [t T]
+| PS2_U			 |85| [u U]
+| PS2_V			 |86| [v V]
+| PS2_W			 |87| [w W]
+| PS2_X			 |88| [x X]
+| PS2_Y			 |89| [y Y]
+| PS2_Z			 |90| [z Z]
 
 
 (3)テンキーのキーコード
 
 | 定義名 | 値 |意味|
 |--------|----------|------|
-| KEY_PAD_Equal |94	| [=]
-| KEY_PAD_Enter	|95	| [Enter]
-| KEY_PAD_0		|96 | [0/Insert]
-| KEY_PAD_1		|97 | [1/End]
-| KEY_PAD_2		|98 | [2/DownArrow]
-| KEY_PAD_3		|99 | [3/PageDown]
-| KEY_PAD_4		|100| [4/LeftArrow]
-| KEY_PAD_5		|101| [5]
-| KEY_PAD_6		|102| [6/RightArrow]
-| KEY_PAD_7		|103| [7/Home]
-| KEY_PAD_8		|104| [8/UPArrow]
-| KEY_PAD_9		|105| [9/PageUp]
-| KEY_PAD_Multi	|106| [*]
-| KEY_PAD_Plus	|107| [+]
-| KEY_PAD_Kamma	|108| [,]
-| KEY_PAD_Minus	|109| [-]
-| KEY_PAD_DOT	|110| [./Delete]
-| KEY_PAD_Slash	|111| [/]
+| PS2_PAD_Equal |94	| [=]
+| PS2_PAD_Enter	|95	| [Enter]
+| PS2_PAD_0		|96 | [0/Insert]
+| PS2_PAD_1		|97 | [1/End]
+| PS2_PAD_2		|98 | [2/DownArrow]
+| PS2_PAD_3		|99 | [3/PageDown]
+| PS2_PAD_4		|100| [4/LeftArrow]
+| PS2_PAD_5		|101| [5]
+| PS2_PAD_6		|102| [6/RightArrow]
+| PS2_PAD_7		|103| [7/Home]
+| PS2_PAD_8		|104| [8/UPArrow]
+| PS2_PAD_9		|105| [9/PageUp]
+| PS2_PAD_Multi	|106| [*]
+| PS2_PAD_Plus	|107| [+]
+| PS2_PAD_Kamma	|108| [,]
+| PS2_PAD_Minus	|109| [-]
+| PS2_PAD_DOT	|110| [./Delete]
+| PS2_PAD_Slash	|111| [/]
 
 (4)ファンクションキーのキーコード
 
 | 定義名 | 値 |意味|
 |----------|--------|------|
-| KEY_F1 	|112	| [F1]
-| KEY_F2 	|113	| [F2]
-| KEY_F3 	|114	| [F3]
-| KEY_F4 	|115	| [F4]
-| KEY_F5 	|116	| [F5]
-| KEY_F6 	|117	| [F6]
-| KEY_F7 	|118	| [F7]
-| KEY_F8 	|119	| [F8]
-| KEY_F9 	|120	| [F9]
-| KEY_F10 	|121	| [F10]
-| KEY_F11 	|122	| [F11]
-| KEY_F12 	|123	| [F12]
-| KEY_F13 	|124	| [F13]
-| KEY_F14 	|125	| [F14]
-| KEY_F15 	|126	| [F15]
-| KEY_F16 	|127	| [F16]
-| KEY_F17 	|128	| [F17]
-| KEY_F18 	|129	| [F18]
-| KEY_F19 	|130	| [F19]
-| KEY_F20 	|131	| [F20]
-| KEY_F21 	|132	| [F21]
-| KEY_F22 	|133	| [F22]
-| KEY_F23 	|134	| [F23]
+| PS2_F1 	|112	| [F1]
+| PS2_F2 	|113	| [F2]
+| PS2_F3 	|114	| [F3]
+| PS2_F4 	|115	| [F4]
+| PS2_F5 	|116	| [F5]
+| PS2_F6 	|117	| [F6]
+| PS2_F7 	|118	| [F7]
+| PS2_F8 	|119	| [F8]
+| PS2_F9 	|120	| [F9]
+| PS2_F10 	|121	| [F10]
+| PS2_F11 	|122	| [F11]
+| PS2_F12 	|123	| [F12]
+| PS2_F13 	|124	| [F13]
+| PS2_F14 	|125	| [F14]
+| PS2_F15 	|126	| [F15]
+| PS2_F16 	|127	| [F16]
+| PS2_F17 	|128	| [F17]
+| PS2_F18 	|129	| [F18]
+| PS2_F19 	|130	| [F19]
+| PS2_F20 	|131	| [F20]
+| PS2_F21 	|132	| [F21]
+| PS2_F22 	|133	| [F22]
+| PS2_F23 	|134	| [F23]
 
 (5)マルチマディアキーのキーコード
 
 | 定義名 | 値 |意味|
 |-------------------|---|---------------|
-| KEY_PrevTrack		|135| 前のトラック
-| KEY_WWW_Favorites	|136| ブラウザお気に入り
-| LEY_WWW_Refresh	|137| ブラウザ更新表示
-| KEY_VolumeDown	|138| 音量を下げる
-| KEY_Mute			|139| ミュート
-| KEY_WWW_Stop		|140| ブラウザ停止
-| KEY_Calc			|141| 電卓
-| KEY_WWW_Forward	|142| ブラウザ進む
-| KEY_VolumeUp		|143| 音量を上げる
-| KEY_PLAY			|144| 再生
-| KEY_POWER			|145| 電源ON
-| KEY_WWW_Back		|146| ブラウザ戻る
-| KEY_WWW_Home		|147| ブラウザホーム
-| KEY_Sleep			|148| スリープ
-| KEY_Mycomputer	|149| マイコンピュータ
-| KEY_Mail			|150| メーラー起動
-| KEY_NextTrack		|151| 次のトラック
-| KEY_MEdiaSelect	|152| メディア選択
-| KEY_Wake			|153| ウェイクアップ
-| KEY_Stop			|154| 停止
-| KEY_WWW_Search	|155| ウェブ検索
+| PS2_PrevTrack		|135| 前のトラック
+| PS2_WWW_Favorites	|136| ブラウザお気に入り
+| PS2_WWW_Refresh	|137| ブラウザ更新表示
+| PS2_VolumeDown	|138| 音量を下げる
+| PS2_Mute			|139| ミュート
+| PS2_WWW_Stop		|140| ブラウザ停止
+| PS2_Calc			|141| 電卓
+| PS2_WWW_Forward	|142| ブラウザ進む
+| PS2_VolumeUp		|143| 音量を上げる
+| PS2_PLAY			|144| 再生
+| PS2_POWER			|145| 電源ON
+| PS2_WWW_Back		|146| ブラウザ戻る
+| PS2_WWW_Home		|147| ブラウザホーム
+| PS2_Sleep			|148| スリープ
+| PS2_Mycomputer	|149| マイコンピュータ
+| PS2_Mail			|150| メーラー起動
+| PS2_NextTrack		|151| 次のトラック
+| PS2_MEdiaSelect	|152| メディア選択
+| PS2_Wake			|153| ウェイクアップ
+| PS2_Stop			|154| 停止
+| PS2_WWW_Search	|155| ウェブ検索
 
 ## サンプルスケッチ
 TKeyboard_exsample.ino

--- a/TKeyboard/src/TKeyboard.cpp
+++ b/TKeyboard/src/TKeyboard.cpp
@@ -8,6 +8,7 @@
 // 修正日 2017/02/05, setPriority()関数の追加、ctrl_LED()の処理方式変更
 // 修正日 2017/02/05, KEY_SPACEのキーコード変更(32=>35)対応
 // 修正日 2017/04/10, NumLock+編集キーの不具合暫定対応
+// 修正日 2018/08/22, キーコードマクロ名をKEY_XXXからPS2_XXXに変更(文字コードとの混乱回避のため）
 //
 
 #include <TKeyboard.h>
@@ -42,38 +43,38 @@ volatile static uint8_t (*key_ascii)[2];
 // スキャンコード 0x00-0x83 => キーコード変換テーブル
 // 132バイト分
 static uint8_t keycode1[] __FLASH__ = {
- 0            , KEY_F9      , 0           , KEY_F5         , KEY_F3        , KEY_F1         , KEY_F2        , KEY_F12,       // 0x00-0x07
- KEY_F13      , KEY_F10     , KEY_F8      , KEY_F6         , KEY_F4        , KEY_Tab        , KEY_HanZen    , KEY_PAD_Equal, // 0x08-0x0F
- KEY_F14      , KEY_L_Alt   , KEY_L_Shift , KEY_Romaji     , KEY_L_Ctrl    , KEY_Q          , KEY_1         , 0,             // 0x10-0x17
- KEY_F15      , 0           , KEY_Z       , KEY_S          , KEY_A         , KEY_W          , KEY_2         , 0,             // 0x18-0x1F
- KEY_F16      , KEY_C       , KEY_X       , KEY_D          , KEY_E         , KEY_4          , KEY_3         , 0,             // 0x20-0x27
- KEY_F17      , KEY_Space   , KEY_V       , KEY_F          , KEY_T         , KEY_R          , KEY_5         , 0,             // 0x28-0x2F
- KEY_F18      , KEY_N       , KEY_B       , KEY_H          , KEY_G         , KEY_Y          , KEY_6         , 0,             // 0x30-0x37
- KEY_F19      , 0           , KEY_M       , KEY_J          , KEY_U         , KEY_7          , KEY_8         , 0,             // 0x38-0x3F
- KEY_F20      , KEY_Kamma   , KEY_K       , KEY_I          , KEY_O         , KEY_0          , KEY_9         , 0,             // 0x40-0x47
- KEY_F21      , KEY_Dot     , KEY_Question, KEY_L          , KEY_Semicolon , KEY_P          , KEY_minus     , 0,             // 0x48-0x4F
- KEY_F22      , KEY_Ro      , KEY_Colon   , 0              , KEY_AT        , KEY_Hat        , 0             , KEY_F23,       // 0x50-0x57
- KEY_CapsLock , KEY_R_Shift , KEY_Enter   , KEY_L_brackets , 0             , KEY_R_brackets , 0             , 0,             // 0x58-0x5F
- 0            , KEY_Pipe2   , 0           , 0              , KEY_Henkan    , 0              , KEY_Backspace , KEY_Muhenkan,  // 0x60-0x67
- 0            , KEY_PAD_1   , KEY_Pipe    , KEY_PAD_4      , KEY_PAD_7     , KEY_PAD_Kamma  , 0             , 0,             // 0x68-0x6F
- KEY_PAD_0    , KEY_PAD_DOT , KEY_PAD_2   , KEY_PAD_5      , KEY_PAD_6     , KEY_PAD_8      , KEY_ESC       , KEY_NumLock,   // 0x70-0x77
- KEY_F11      , KEY_PAD_Plus, KEY_PAD_3   , KEY_PAD_Minus  , KEY_PAD_Multi , KEY_PAD_9      , KEY_ScrollLock, 0,             // 0x78-0x7F
- 0            , 0           , 0           , KEY_F7         ,                                                                 // 0x80-0x83
+ 0            , PS2_F9      , 0           , PS2_F5         , PS2_F3        , PS2_F1         , PS2_F2        , PS2_F12,       // 0x00-0x07
+ PS2_F13      , PS2_F10     , PS2_F8      , PS2_F6         , PS2_F4        , PS2_Tab        , PS2_HanZen    , PS2_PAD_Equal, // 0x08-0x0F
+ PS2_F14      , PS2_L_Alt   , PS2_L_Shift , PS2_Romaji     , PS2_L_Ctrl    , PS2_Q          , PS2_1         , 0,             // 0x10-0x17
+ PS2_F15      , 0           , PS2_Z       , PS2_S          , PS2_A         , PS2_W          , PS2_2         , 0,             // 0x18-0x1F
+ PS2_F16      , PS2_C       , PS2_X       , PS2_D          , PS2_E         , PS2_4          , PS2_3         , 0,             // 0x20-0x27
+ PS2_F17      , PS2_Space   , PS2_V       , PS2_F          , PS2_T         , PS2_R          , PS2_5         , 0,             // 0x28-0x2F
+ PS2_F18      , PS2_N       , PS2_B       , PS2_H          , PS2_G         , PS2_Y          , PS2_6         , 0,             // 0x30-0x37
+ PS2_F19      , 0           , PS2_M       , PS2_J          , PS2_U         , PS2_7          , PS2_8         , 0,             // 0x38-0x3F
+ PS2_F20      , PS2_Kamma   , PS2_K       , PS2_I          , PS2_O         , PS2_0          , PS2_9         , 0,             // 0x40-0x47
+ PS2_F21      , PS2_Dot     , PS2_Question, PS2_L          , PS2_Semicolon , PS2_P          , PS2_minus     , 0,             // 0x48-0x4F
+ PS2_F22      , PS2_Ro      , PS2_Colon   , 0              , PS2_AT        , PS2_Hat        , 0             , PS2_F23,       // 0x50-0x57
+ PS2_CapsLock , PS2_R_Shift , PS2_Enter   , PS2_L_brackets , 0             , PS2_R_brackets , 0             , 0,             // 0x58-0x5F
+ 0            , PS2_Pipe2   , 0           , 0              , PS2_Henkan    , 0              , PS2_Backspace , PS2_Muhenkan,  // 0x60-0x67
+ 0            , PS2_PAD_1   , PS2_Pipe    , PS2_PAD_4      , PS2_PAD_7     , PS2_PAD_Kamma  , 0             , 0,             // 0x68-0x6F
+ PS2_PAD_0    , PS2_PAD_DOT , PS2_PAD_2   , PS2_PAD_5      , PS2_PAD_6     , PS2_PAD_8      , PS2_ESC       , PS2_NumLock,   // 0x70-0x77
+ PS2_F11      , PS2_PAD_Plus, PS2_PAD_3   , PS2_PAD_Minus  , PS2_PAD_Multi , PS2_PAD_9      , PS2_ScrollLock, 0,             // 0x78-0x7F
+ 0            , 0           , 0           , PS2_F7         ,                                                                 // 0x80-0x83
 }; 
 
 // スキャンコード 0xE010-0xE07D => キーコード変換テーブル
 // 2バイト(スキャンコード下位1バイト, キーコード) x 38
 static uint8_t keycode2[][2] __FLASH__ = {
- { 0x10 , KEY_WWW_Search },    { 0x11 , KEY_R_Alt },      { 0x14 , KEY_R_Ctrl },      { 0x15 , KEY_PrevTrack },
- { 0x18 , KEY_WWW_Favorites }, { 0x1F , KEY_L_GUI },      { 0x20 , LEY_WWW_Refresh }, { 0x21 , KEY_VolumeDown },
- { 0x23 , KEY_Mute },          { 0x27 , KEY_R_GUI },      { 0x28 , KEY_WWW_Stop },    { 0x2B , KEY_Calc },
- { 0x2F , KEY_APP },           { 0x30 , KEY_WWW_Forward },{ 0x32 , KEY_VolumeUp },    { 0x34 , KEY_PLAY },
- { 0x37 , KEY_POWER },         { 0x38 , KEY_WWW_Back },   { 0x3A , KEY_WWW_Home },    { 0x3B , KEY_Stop },
- { 0x3F , KEY_Sleep },         { 0x40 , KEY_Mycomputer }, { 0x48 , KEY_Mail },        { 0x4A , KEY_PAD_Slash },
- { 0x4D , KEY_NextTrack },     { 0x50 , KEY_MEdiaSelect },{ 0x5A , KEY_PAD_Enter },   { 0x5E , KEY_Wake },
- { 0x69 , KEY_End },           { 0x6B , KEY_L_Arrow },    { 0x6C , KEY_Home },        { 0x70 , KEY_Insert },
- { 0x71 , KEY_Delete },        { 0x72 , KEY_Down_Arrow }, { 0x74 , KEY_R_Arrow },     { 0x75 , KEY_Up_Arrow },
- { 0x7A , KEY_PageDown },      { 0x7D , KEY_PageUp },
+ { 0x10 , PS2_WWW_Search },    { 0x11 , PS2_R_Alt },      { 0x14 , PS2_R_Ctrl },      { 0x15 , PS2_PrevTrack },
+ { 0x18 , PS2_WWW_Favorites }, { 0x1F , PS2_L_GUI },      { 0x20 , PS2_WWW_Refresh }, { 0x21 , PS2_VolumeDown },
+ { 0x23 , PS2_Mute },          { 0x27 , PS2_R_GUI },      { 0x28 , PS2_WWW_Stop },    { 0x2B , PS2_Calc },
+ { 0x2F , PS2_APP },           { 0x30 , PS2_WWW_Forward },{ 0x32 , PS2_VolumeUp },    { 0x34 , PS2_PLAY },
+ { 0x37 , PS2_POWER },         { 0x38 , PS2_WWW_Back },   { 0x3A , PS2_WWW_Home },    { 0x3B , PS2_Stop },
+ { 0x3F , PS2_Sleep },         { 0x40 , PS2_Mycomputer }, { 0x48 , PS2_Mail },        { 0x4A , PS2_PAD_Slash },
+ { 0x4D , PS2_NextTrack },     { 0x50 , PS2_MEdiaSelect },{ 0x5A , PS2_PAD_Enter },   { 0x5E , PS2_Wake },
+ { 0x69 , PS2_End },           { 0x6B , PS2_L_Arrow },    { 0x6C , PS2_Home },        { 0x70 , PS2_Insert },
+ { 0x71 , PS2_Delete },        { 0x72 , PS2_Down_Arrow }, { 0x74 , PS2_R_Arrow },     { 0x75 , PS2_Up_Arrow },
+ { 0x7A , PS2_PageDown },      { 0x7D , PS2_PageUp },
 };
 
 // Pause Key スキャンコード
@@ -115,20 +116,20 @@ static uint8_t key_ascii_jp[][2] __FLASH__ = {
 static uint8_t tenkey[][3]  __FLASH__ = {
   { '=',  '='            ,0},
   { 0x0D, 0x0D           ,0},
-  { '0',  KEY_Insert     ,1},
-  { '1',  KEY_End        ,1},
-  { '2',  KEY_Down_Arrow ,1},
-  { '3',  KEY_PageDown   ,1},
-  { '4',  KEY_L_Arrow    ,1},
+  { '0',  PS2_Insert     ,1},
+  { '1',  PS2_End        ,1},
+  { '2',  PS2_Down_Arrow ,1},
+  { '3',  PS2_PageDown   ,1},
+  { '4',  PS2_L_Arrow    ,1},
   { '5',  '5'            ,0},
-  { '6',  KEY_R_Arrow    ,1},
-  { '7',  KEY_Home       ,1},
-  { '8',  KEY_Up_Arrow   ,1},
-  { '9',  KEY_PageUp     ,1},
+  { '6',  PS2_R_Arrow    ,1},
+  { '7',  PS2_Home       ,1},
+  { '8',  PS2_Up_Arrow   ,1},
+  { '9',  PS2_PageUp     ,1},
   { '*',  '*'            ,0},
   { '+',  '+'            ,0},
   { ',',  ','            ,1},
-  { '-',  KEY_PAD_Minus  ,1},
+  { '-',  PS2_PAD_Minus  ,1},
   { '.',  0x7f           ,0},
   { '/',  '/'            ,0},
 };
@@ -262,7 +263,7 @@ uint8_t TKeyboard::findcode(uint8_t c)  {
 uint16_t TKeyboard::scanToKeycode() {
   static uint8_t state = STS_SYOKI;
   static uint8_t scIndex = 0;
-  uint16_t c,c2, code = 0;
+  uint16_t c, code = 0;
 
   while(pb.available()) {
     c = pb.dequeue();     // キューから1バイト取り出し
@@ -332,7 +333,7 @@ uint16_t TKeyboard::scanToKeycode() {
         if (c == prnScrncode2[scIndex]) {
           if (scIndex == sizeof(prnScrncode2)-1) {
             // ->[3-2-2-1-1-1](END)
-            code = KEY_PrintScreen | BREAK_CODE; // BREAK+PrintScreen
+            code = PS2_PrintScreen | BREAK_CODE; // BREAK+PrintScreen
             goto DONE;            
           } else {
             continue;
@@ -349,17 +350,17 @@ uint16_t TKeyboard::scanToKeycode() {
       
       case STS_MKEY_SC3:
     	switch(c) {
-    		case 0x70:code = KEY_Insert;      goto DONE;break; // [INS]
-    		case 0x71:code = KEY_Delete;      goto DONE;break; // [DEL]
-    	    case 0x6B:code = KEY_L_Arrow;     goto DONE;break; // [←]
-    	    case 0x6C:code = KEY_Home;        goto DONE;break; // [HOME]
-    	    case 0x69:code = KEY_End;         goto DONE;break; // [END]
-    	    case 0x75:code = KEY_Up_Arrow;    goto DONE;break; // [↑]
-    	    case 0x72:code = KEY_Down_Arrow;  goto DONE;break; // [↓]
-    	    case 0x7d:code = KEY_PageUp;      goto DONE;break; // [PageUp]
-    	    case 0x7a:code = KEY_PageDown;    goto DONE;break; // [PageDown]
-    	    case 0x74:code = KEY_R_Arrow;     goto DONE;break; // [→]
-    	    case 0x7C:code = KEY_PrintScreen; goto DONE;break; // [PrintScreen]
+    		case 0x70:code = PS2_Insert;      goto DONE;break; // [INS]
+    		case 0x71:code = PS2_Delete;      goto DONE;break; // [DEL]
+    	    case 0x6B:code = PS2_L_Arrow;     goto DONE;break; // [←]
+    	    case 0x6C:code = PS2_Home;        goto DONE;break; // [HOME]
+    	    case 0x69:code = PS2_End;         goto DONE;break; // [END]
+    	    case 0x75:code = PS2_Up_Arrow;    goto DONE;break; // [↑]
+    	    case 0x72:code = PS2_Down_Arrow;  goto DONE;break; // [↓]
+    	    case 0x7d:code = PS2_PageUp;      goto DONE;break; // [PageUp]
+    	    case 0x7a:code = PS2_PageDown;    goto DONE;break; // [PageDown]
+    	    case 0x74:code = PS2_R_Arrow;     goto DONE;break; // [→]
+    	    case 0x7C:code = PS2_PrintScreen; goto DONE;break; // [PrintScreen]
     	    default:  goto STS_ERROR;break;  // -> ERROR
     	}
   	
@@ -373,7 +374,7 @@ uint16_t TKeyboard::scanToKeycode() {
         if (c == pausescode[scIndex]) {
           if (scIndex == sizeof(pausescode)-1) {
             // ->[4-1-1-1-1-1-1-1](END)
-            code = KEY_Pause; // Pause key
+            code = PS2_Pause; // Pause key
             goto DONE;            
           } else {
             continue;
@@ -440,27 +441,27 @@ keyEvent TKeyboard::read() {
  	  goto DONE; // キー入力なし、またはエラー
 
   // 通常キー
-//  if (code >= KEY_ESC && code <= KEY_Z) {
-  if (code >= KEY_Space && code <= KEY_Z) {	
-     if (code >= KEY_A && code <= KEY_Z)  // A-ZのCapsLockキー状態に影響するキーの場合の処理
-        c.value = key_ascii[code-KEY_Space][((sts_CapsLock&1)&&sts_state.kevt.SHIFT)||(!(sts_CapsLock&1)&&!sts_state.kevt.SHIFT)?0:1];
+//  if (code >= PS2_ESC && code <= PS2_Z) {
+  if (code >= PS2_Space && code <= PS2_Z) {	
+     if (code >= PS2_A && code <= PS2_Z)  // A-ZのCapsLockキー状態に影響するキーの場合の処理
+        c.value = key_ascii[code-PS2_Space][((sts_CapsLock&1)&&sts_state.kevt.SHIFT)||(!(sts_CapsLock&1)&&!sts_state.kevt.SHIFT)?0:1];
       else 
-        c.value = key_ascii[code-KEY_Space][sts_state.kevt.SHIFT?1:0];
+        c.value = key_ascii[code-PS2_Space][sts_state.kevt.SHIFT?1:0];
      goto DONE;
      
-  } else if (code >= KEY_PAD_Equal && code <= KEY_PAD_Slash) {
+  } else if (code >= PS2_PAD_Equal && code <= PS2_PAD_Slash) {
    // テンキー
    if ( (sts_numlock & 1) &&  !sts_state.kevt.SHIFT ) {
       // NumLock有効でShiftが押させていない場合
-      c.value = tenkey[code-KEY_PAD_Equal][0];      
+      c.value = tenkey[code-PS2_PAD_Equal][0];      
       //Serial.println("[DEBUG:NumLock]");
    } else {
-      c.value = tenkey[code-KEY_PAD_Equal][1];
-      if (tenkey[code-KEY_PAD_Equal][2]) c.value |= KEY_CODE;
+      c.value = tenkey[code-PS2_PAD_Equal][1];
+      if (tenkey[code-PS2_PAD_Equal][2]) c.value |= KEY_CODE;
   	}
   	goto DONE;
     
-  } else if (code >=KEY_L_Alt && code <= KEY_CapsLock) {
+  } else if (code >=PS2_L_Alt && code <= PS2_CapsLock) {
     // 入力制御キー
 
     // 操作前のLockキーの状態を保存
@@ -469,15 +470,15 @@ keyEvent TKeyboard::read() {
     uint8_t prv_ScrolLock = sts_ScrolLock & 1;
   
     switch(code) {
-  	  case KEY_L_Shift:  // Shiftキー
-  	  case KEY_R_Shift:  sts_state.kevt.SHIFT = bk?0:1; break;
-  	  case KEY_L_Ctrl:   // Ctrlキー
-  	  case KEY_R_Ctrl:   sts_state.kevt.CTRL = bk?0:1;  break;
-  	  case KEY_L_Alt:    // Altキー
-  	  case KEY_R_Alt:    sts_state.kevt.ALT = bk?0:1; break; 	 
-      case KEY_L_GUI:    // Windowsキー
-      case KEY_R_GUI:    sts_state.kevt.GUI = bk ? 0:1;  break; 
-  	  case KEY_CapsLock: // CapsLockキー(トグル動作)
+  	  case PS2_L_Shift:  // Shiftキー
+  	  case PS2_R_Shift:  sts_state.kevt.SHIFT = bk?0:1; break;
+  	  case PS2_L_Ctrl:   // Ctrlキー
+  	  case PS2_R_Ctrl:   sts_state.kevt.CTRL = bk?0:1;  break;
+  	  case PS2_L_Alt:    // Altキー
+  	  case PS2_R_Alt:    sts_state.kevt.ALT = bk?0:1; break; 	 
+      case PS2_L_GUI:    // Windowsキー
+      case PS2_R_GUI:    sts_state.kevt.GUI = bk ? 0:1;  break; 
+  	  case PS2_CapsLock: // CapsLockキー(トグル動作)
     		switch (sts_CapsLock) {
           case LOCK_Start:	  if (!bk) sts_CapsLock = LOCK_ON_Make; break;  // 初期
   		    case LOCK_ON_Make:  if (bk)  sts_CapsLock = LOCK_ON_Break; break; // LOCK ON キーを押したままの状態
@@ -486,7 +487,7 @@ keyEvent TKeyboard::read() {
   		    default: sts_CapsLock = LOCK_Start; break;
   		  }
   		  break; 		
-  	  case KEY_ScrollLock: // ScrollLockキー(トグル動作)
+  	  case PS2_ScrollLock: // ScrollLockキー(トグル動作)
         switch (sts_ScrolLock) {
           case LOCK_Start:    if (!bk) sts_ScrolLock = LOCK_ON_Make; break;  // 初期
           case LOCK_ON_Make:  if (bk)  sts_ScrolLock = LOCK_ON_Break; break; // LOCK ON キーを押したままの状態
@@ -495,7 +496,7 @@ keyEvent TKeyboard::read() {
           default: sts_ScrolLock = LOCK_Start; break;
         }
         break; 
-      case KEY_NumLock: // NumLockキー(トグル動作)
+      case PS2_NumLock: // NumLockキー(トグル動作)
         switch (sts_numlock) {
           case LOCK_Start:    if (!bk) sts_numlock  = LOCK_ON_Make; break;  // 初期
           case LOCK_ON_Make:  if (bk)  sts_numlock  = LOCK_ON_Break; break; // LOCK ON キーを押したままの状態
@@ -513,7 +514,7 @@ keyEvent TKeyboard::read() {
        ctrl_LED(sts_CapsLock & 1, sts_numlock & 1, sts_ScrolLock & 1);
     goto DONE;
 
-  } else if (code == KEY_HanZen && _flgUS) {
+  } else if (code == PS2_HanZen && _flgUS) {
     if (sts_state.kevt.SHIFT)
       c.value = '`';
     else

--- a/TKeyboard/src/TKeyboard.h
+++ b/TKeyboard/src/TKeyboard.h
@@ -4,6 +4,7 @@
 // 作成日 2017/01/31
 // 修正日 2017/02/05, setPriority()関数の追加
 // 修正日 2017/02/05, KEY_SPACEのキーコード変更(32=>35)
+// 修正日 2018/08/22, キーコードマクロ名をKEY_XXXからPS2_XXXに変更(文字コードとの混乱回避のため）
 //
 
 #ifndef __TKEYBOARD_H__
@@ -23,159 +24,159 @@
 #define KEY_NONE              0  // 継続またはバッファに変換対象なし
 
 // キーコード定義(JIS配列キーボード)
-#define KEY_L_Alt		    1	// [左Alt]
-#define KEY_L_Shift		  2	// [左Shift]
-#define KEY_L_Ctrl		  3	// [左Ctrl]
-#define KEY_R_Shift		  4	// [右Shift]
-#define KEY_R_Alt		    5	// [右Alt]
-#define KEY_R_Ctrl		  6	// [右Ctrl]
-#define KEY_L_GUI		    7	// [左Windowsキー]
-#define KEY_R_GUI		    8	// [右Windowsキー]
-#define KEY_NumLock		  9	// [NumLock]
-#define KEY_ScrollLock	10	// [ScrollLock]
-#define KEY_CapsLock	  11	// [CapsLock]
-#define KEY_PrintScreen	12	// [PrintScreen]
-#define KEY_HanZen		  13	// [半角/全角 漢字]
-#define KEY_Insert		  14	// [Insert]
-#define KEY_Home		    15	// [Home]
-#define KEY_Pause		    16	// [Pause]
-#define KEY_Romaji		  17	// [カタカナ ひらがな ローマ字]
-#define KEY_APP			    18	// [メニューキー]
-#define KEY_Henkan		  19	// [変換]
-#define KEY_Muhenkan	  20	// [無変換]
-#define KEY_PageUp		  21	// [PageUp]
-#define KEY_PageDown	  22	// [PageDown]
-#define KEY_End			    23	// [End]
-#define KEY_L_Arrow		  24	// [←]
-#define KEY_Up_Arrow	  25	// [↑]
-#define KEY_R_Arrow		  26	// [→]
-#define KEY_Down_Arrow	27	// [↓]
+#define PS2_L_Alt		    1	// [左Alt]
+#define PS2_L_Shift		  2	// [左Shift]
+#define PS2_L_Ctrl		  3	// [左Ctrl]
+#define PS2_R_Shift		  4	// [右Shift]
+#define PS2_R_Alt		    5	// [右Alt]
+#define PS2_R_Ctrl		  6	// [右Ctrl]
+#define PS2_L_GUI		    7	// [左Windowsキー]
+#define PS2_R_GUI		    8	// [右Windowsキー]
+#define PS2_NumLock		  9	// [NumLock]
+#define PS2_ScrollLock	10	// [ScrollLock]
+#define PS2_CapsLock	  11	// [CapsLock]
+#define PS2_PrintScreen	12	// [PrintScreen]
+#define PS2_HanZen		  13	// [半角/全角 漢字]
+#define PS2_Insert		  14	// [Insert]
+#define PS2_Home		    15	// [Home]
+#define PS2_Pause		    16	// [Pause]
+#define PS2_Romaji		  17	// [カタカナ ひらがな ローマ字]
+#define PS2_APP			    18	// [メニューキー]
+#define PS2_Henkan		  19	// [変換]
+#define PS2_Muhenkan	  20	// [無変換]
+#define PS2_PageUp		  21	// [PageUp]
+#define PS2_PageDown	  22	// [PageDown]
+#define PS2_End			    23	// [End]
+#define PS2_L_Arrow		  24	// [←]
+#define PS2_Up_Arrow	  25	// [↑]
+#define PS2_R_Arrow		  26	// [→]
+#define PS2_Down_Arrow	27	// [↓]
 
-#define KEY_ESC			    30	// [ESC]
-#define KEY_Tab 		    31	// [Tab]
-#define KEY_Enter       32  // [Enter]
-#define KEY_Space		    35	// [空白]
-#define KEY_Backspace	  33	// [BackSpace]
-#define KEY_Delete		  34	// [Delete]
+#define PS2_ESC			    30	// [ESC]
+#define PS2_Tab 		    31	// [Tab]
+#define PS2_Enter       32  // [Enter]
+#define PS2_Space		    35	// [空白]
+#define PS2_Backspace	  33	// [BackSpace]
+#define PS2_Delete		  34	// [Delete]
 
-#define KEY_Colon		    36	// [: *]
-#define KEY_Semicolon	  37	// [; +]
-#define KEY_Kamma		    38	// [, <]
-#define KEY_minus		    39	// [- =]
-#define KEY_Dot			    40	// [. >]
-#define KEY_Question	  41	// [/ ?]
-#define KEY_AT			    42	// [@ `]
-#define KEY_L_brackets	43	// [[ {]
-#define KEY_Pipe		    44	// [\ |]
-#define KEY_R_brackets	45	// [] }]
-#define KEY_Hat			    46	// [^ ~]
-#define KEY_Ro			    47	// [\ _ ろ]
+#define PS2_Colon		    36	// [: *]
+#define PS2_Semicolon	  37	// [; +]
+#define PS2_Kamma		    38	// [, <]
+#define PS2_minus		    39	// [- =]
+#define PS2_Dot			    40	// [. >]
+#define PS2_Question	  41	// [/ ?]
+#define PS2_AT			    42	// [@ `]
+#define PS2_L_brackets	43	// [[ {]
+#define PS2_Pipe		    44	// [\ |]
+#define PS2_R_brackets	45	// [] }]
+#define PS2_Hat			    46	// [^ ~]
+#define PS2_Ro			    47	// [\ _ ろ]
 
-#define KEY_0			48	// [0 )]
-#define KEY_1			49	// [1 !]
-#define KEY_2			50	// [2 @]
-#define KEY_3			51	// [3 #]
-#define KEY_4			52	// [4 $]
-#define KEY_5			53	// [5 %]
-#define KEY_6			54	// [6 ^]
-#define KEY_7			55	// [7 &]
-#define KEY_8			56	// [8 *]
-#define KEY_9			57	// [9 (]
-#define KEY_Pipe2 58  // [\ |] (USキーボード用)
-#define KEY_A			65	// [a A]
-#define KEY_B			66	// [b B]
-#define KEY_C			67	// [c C]
-#define KEY_D			68	// [d D]
-#define KEY_E			69	// [e E]
-#define KEY_F			70	// [f F]
-#define KEY_G			71	// [g G]
-#define KEY_H			72	// [h H]
-#define KEY_I			73	// [i I]
-#define KEY_J			74	// [j J]
-#define KEY_K			75	// [k K]
-#define KEY_L			76	// [l L]
-#define KEY_M			77	// [m M]
-#define KEY_N			78	// [n N]
-#define KEY_O			79	// [o O]
-#define KEY_P			80	// [p P]
-#define KEY_Q			81	// [q Q]
-#define KEY_R			82	// [r R]
-#define KEY_S			83	// [s S]
-#define KEY_T			84	// [t T]
-#define KEY_U			85	// [u U]
-#define KEY_V			86	// [v V]
-#define KEY_W			87	// [w W]
-#define KEY_X			88	// [x X]
-#define KEY_Y			89	// [y Y]
-#define KEY_Z			90	// [z Z]
+#define PS2_0			48	// [0 )]
+#define PS2_1			49	// [1 !]
+#define PS2_2			50	// [2 @]
+#define PS2_3			51	// [3 #]
+#define PS2_4			52	// [4 $]
+#define PS2_5			53	// [5 %]
+#define PS2_6			54	// [6 ^]
+#define PS2_7			55	// [7 &]
+#define PS2_8			56	// [8 *]
+#define PS2_9			57	// [9 (]
+#define PS2_Pipe2 58  // [\ |] (USキーボード用)
+#define PS2_A			65	// [a A]
+#define PS2_B			66	// [b B]
+#define PS2_C			67	// [c C]
+#define PS2_D			68	// [d D]
+#define PS2_E			69	// [e E]
+#define PS2_F			70	// [f F]
+#define PS2_G			71	// [g G]
+#define PS2_H			72	// [h H]
+#define PS2_I			73	// [i I]
+#define PS2_J			74	// [j J]
+#define PS2_K			75	// [k K]
+#define PS2_L			76	// [l L]
+#define PS2_M			77	// [m M]
+#define PS2_N			78	// [n N]
+#define PS2_O			79	// [o O]
+#define PS2_P			80	// [p P]
+#define PS2_Q			81	// [q Q]
+#define PS2_R			82	// [r R]
+#define PS2_S			83	// [s S]
+#define PS2_T			84	// [t T]
+#define PS2_U			85	// [u U]
+#define PS2_V			86	// [v V]
+#define PS2_W			87	// [w W]
+#define PS2_X			88	// [x X]
+#define PS2_Y			89	// [y Y]
+#define PS2_Z			90	// [z Z]
 
 // テンキー
-#define KEY_PAD_Equal	94	// [=]
-#define KEY_PAD_Enter	95	// [Enter]
-#define KEY_PAD_0		96  	// [0/Insert]
-#define KEY_PAD_1		97  	// [1/End]
-#define KEY_PAD_2		98  	// [2/DownArrow]
-#define KEY_PAD_3		99  	// [3/PageDown]
-#define KEY_PAD_4		100 	// [4/LeftArrow]
-#define KEY_PAD_5		101 	// [5]
-#define KEY_PAD_6		102 	// [6/RightArrow]
-#define KEY_PAD_7		103 	// [7/Home]
-#define KEY_PAD_8		104 	// [8/UPArrow]
-#define KEY_PAD_9		105	  // [9/PageUp]
-#define KEY_PAD_Multi	106	// [*]
-#define KEY_PAD_Plus	107	// [+]
-#define KEY_PAD_Kamma	108	// [,]
-#define KEY_PAD_Minus	109	// [-]
-#define KEY_PAD_DOT		110	// [./Delete]
-#define KEY_PAD_Slash	111	// [/]
+#define PS2_PAD_Equal	94	// [=]
+#define PS2_PAD_Enter	95	// [Enter]
+#define PS2_PAD_0		96  	// [0/Insert]
+#define PS2_PAD_1		97  	// [1/End]
+#define PS2_PAD_2		98  	// [2/DownArrow]
+#define PS2_PAD_3		99  	// [3/PageDown]
+#define PS2_PAD_4		100 	// [4/LeftArrow]
+#define PS2_PAD_5		101 	// [5]
+#define PS2_PAD_6		102 	// [6/RightArrow]
+#define PS2_PAD_7		103 	// [7/Home]
+#define PS2_PAD_8		104 	// [8/UPArrow]
+#define PS2_PAD_9		105	  // [9/PageUp]
+#define PS2_PAD_Multi	106	// [*]
+#define PS2_PAD_Plus	107	// [+]
+#define PS2_PAD_Kamma	108	// [,]
+#define PS2_PAD_Minus	109	// [-]
+#define PS2_PAD_DOT		110	// [./Delete]
+#define PS2_PAD_Slash	111	// [/]
 
 // ファンクションキー
-#define KEY_F1 		112	// [F1]
-#define KEY_F2 		113	// [F2]
-#define KEY_F3 		114	// [F3]
-#define KEY_F4 		115	// [F4]
-#define KEY_F5 		116	// [F5]
-#define KEY_F6 		117	// [F6]
-#define KEY_F7 		118	// [F7]
-#define KEY_F8 		119	// [F8]
-#define KEY_F9 		120	// [F9]
-#define KEY_F10 	121	// [F10]
-#define KEY_F11 	122	// [F11]
-#define KEY_F12 	123	// [F12]
-#define KEY_F13 	124	// [F13]
-#define KEY_F14 	125	// [F14]
-#define KEY_F15 	126	// [F15]
-#define KEY_F16 	127	// [F16]
-#define KEY_F17 	128	// [F17]
-#define KEY_F18 	129	// [F18]
-#define KEY_F19 	130	// [F19]
-#define KEY_F20 	131	// [F20]
-#define KEY_F21 	132	// [F21]
-#define KEY_F22 	133	// [F22]
-#define KEY_F23 	134	// [F23]
+#define PS2_F1 		112	// [F1]
+#define PS2_F2 		113	// [F2]
+#define PS2_F3 		114	// [F3]
+#define PS2_F4 		115	// [F4]
+#define PS2_F5 		116	// [F5]
+#define PS2_F6 		117	// [F6]
+#define PS2_F7 		118	// [F7]
+#define PS2_F8 		119	// [F8]
+#define PS2_F9 		120	// [F9]
+#define PS2_F10 	121	// [F10]
+#define PS2_F11 	122	// [F11]
+#define PS2_F12 	123	// [F12]
+#define PS2_F13 	124	// [F13]
+#define PS2_F14 	125	// [F14]
+#define PS2_F15 	126	// [F15]
+#define PS2_F16 	127	// [F16]
+#define PS2_F17 	128	// [F17]
+#define PS2_F18 	129	// [F18]
+#define PS2_F19 	130	// [F19]
+#define PS2_F20 	131	// [F20]
+#define PS2_F21 	132	// [F21]
+#define PS2_F22 	133	// [F22]
+#define PS2_F23 	134	// [F23]
 
 // マルチマディアキー
-#define KEY_PrevTrack		  135	// 前のトラック
-#define KEY_WWW_Favorites	136	// ブラウザお気に入り
-#define LEY_WWW_Refresh		137	// ブラウザ更新表示
-#define KEY_VolumeDown		138	// 音量を下げる
-#define KEY_Mute			    139	// ミュート
-#define KEY_WWW_Stop		  140	// ブラウザ停止
-#define KEY_Calc			    141	// 電卓
-#define KEY_WWW_Forward		142	// ブラウザ進む
-#define KEY_VolumeUp		  143	// 音量を上げる
-#define KEY_PLAY			    144	// 再生
-#define KEY_POWER			    145	// 電源ON
-#define KEY_WWW_Back		  146	// ブラウザ戻る
-#define KEY_WWW_Home		  147	// ブラウザホーム
-#define KEY_Sleep			    148	// スリープ
-#define KEY_Mycomputer		149	// マイコンピュータ
-#define KEY_Mail			    150	// メーラー起動
-#define KEY_NextTrack		  151	// 次のトラック
-#define KEY_MEdiaSelect		152	// メディア選択
-#define KEY_Wake			    153	// ウェイクアップ
-#define KEY_Stop			    154	// 停止
-#define KEY_WWW_Search		155	// ウェブ検索
+#define PS2_PrevTrack		  135	// 前のトラック
+#define PS2_WWW_Favorites	136	// ブラウザお気に入り
+#define PS2_WWW_Refresh		137	// ブラウザ更新表示
+#define PS2_VolumeDown		138	// 音量を下げる
+#define PS2_Mute			    139	// ミュート
+#define PS2_WWW_Stop		  140	// ブラウザ停止
+#define PS2_Calc			    141	// 電卓
+#define PS2_WWW_Forward		142	// ブラウザ進む
+#define PS2_VolumeUp		  143	// 音量を上げる
+#define PS2_PLAY			    144	// 再生
+#define PS2_POWER			    145	// 電源ON
+#define PS2_WWW_Back		  146	// ブラウザ戻る
+#define PS2_WWW_Home		  147	// ブラウザホーム
+#define PS2_Sleep			    148	// スリープ
+#define PS2_Mycomputer		149	// マイコンピュータ
+#define PS2_Mail			    150	// メーラー起動
+#define PS2_NextTrack		  151	// 次のトラック
+#define PS2_MEdiaSelect		152	// メディア選択
+#define PS2_Wake			    153	// ウェイクアップ
+#define PS2_Stop			    154	// 停止
+#define PS2_WWW_Search		155	// ウェブ検索
 
 // キーボードイベント構造体
 typedef struct  {

--- a/TKeyboard/src/TPS2.cpp
+++ b/TKeyboard/src/TPS2.cpp
@@ -38,7 +38,7 @@ volatile static nvic_irq_num  _irq_num;   // 割り込みベクター番号
 // 戻り値 割り込み番号
 //
 static nvic_irq_num exti2irqNum(exti_num n) {
-  nvic_irq_num irqnum;
+  nvic_irq_num irqnum = NVIC_EXTI0;
   switch(n) {
     case EXTI0: irqnum = NVIC_EXTI0; break;
     case EXTI1: irqnum = NVIC_EXTI1; break;
@@ -503,12 +503,11 @@ uint8_t TPS2::enqueue(uint8_t data) {
   uint16_t n = (_q_top + 1) % QUEUESIZE;
   if (_q_top+1 != _q_btm) {
 	_queue[_q_top] = data;
-	_q_top = n;	
+	_q_top = n;    
   } else {
     return 1;
-    _q_s = 0;
-    return 0;
   }
+  return 0;
 }
 
 // キューからの取出し


### PR DESCRIPTION
文字コードとの混乱回避のため